### PR TITLE
Correct output of class methods

### DIFF
--- a/main.m
+++ b/main.m
@@ -64,7 +64,7 @@ NSString *codeFromFlexPatch(NSDictionary *patch, BOOL comments, BOOL *uikit, BOO
             NSString *bashedMethodTypeValue = displayName.firstObject;
             NSString *returnType = [bashedMethodTypeValue substringFromIndex:2];
             
-            BOOL isClassMethod = [[returnType substringToIndex:1] isEqualToString:@"+"];
+            BOOL isClassMethod = [[bashedMethodTypeValue substringToIndex:1] isEqualToString:@"+"];
             
             NSMutableString *implArgList = [NSMutableString stringWithString:@"(id self, SEL _cmd"];
             NSMutableString *justArgCall = [NSMutableString stringWithString:@"(self, _cmd"];
@@ -179,7 +179,7 @@ NSString *codeFromFlexPatch(NSDictionary *patch, BOOL comments, BOOL *uikit, BOO
                 if (isClassMethod) {
                     NSString *metaClassName = [@"_ftt_metaClass" stringByAppendingString:internalClassName];
                     if (![usedMetaClasses containsObject:metaClassName]) {
-                        [constructor appendFormat:@"    Class %@ = objc_getClass(%@);\n", metaClassName, internalClassName];
+                        [constructor appendFormat:@"    Class %@ = object_getClass(%@);\n", metaClassName, internalClassName];
                         [usedMetaClasses addObject:metaClassName];
                     }
                     internalClassName = metaClassName;


### PR DESCRIPTION
The `isClassMethod` variable in `codeFromFlexPatch` was never being set to `true`, because the incorrect string was being checked. After using the correct string, the output code was not longer compiling. `object_getClass` was changed (from `objc_getClass`) to get the metaclass of the provided class (`objc_getClass` gets the class given a string, `object_getClass` gets the class given an object), as that appeared to be the intended implementation. Notably, `objc_getMetaClass` may be a different solution.