### PR TITLE
Added experimental option to run without Flex installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 SYSROOT = $(THEOS)/sdks/iPhoneOS11.2.sdk
 
     ftt_FRAMEWORKS = UIKit
-    ftt_CODESIGN_FLAGS = -Sent.plist -Icom.ipadkid.ftt
+    ftt_CODESIGN_FLAGS = -Sent.plist
 endif
 
 include $(THEOS)/makefiles/common.mk

--- a/control
+++ b/control
@@ -7,4 +7,4 @@ Homepage: https://github.com/ipadkid358/FlexToTheos
 Maintainer: ipad_kid <ipadkid358@gmail.com>
 Author: ipad_kid <ipadkid358@gmail.com>
 Section: Utilities
-Version: 0.0.5
+Version: 0.0.6

--- a/main.m
+++ b/main.m
@@ -435,15 +435,19 @@ int main(int argc, char *argv[]) {
         NSDictionary *file;
         NSString *firstPath = @"/var/mobile/Library/Application Support/Flex3/patches.plist";
         NSString *secondPath = @"/var/mobile/Library/UserConfigurationProfiles/PublicInfo/Flex3Patches.plist";
+        NSString *thirdPath = @"/var/mobile/Documents/ftt/patches.plist";
         if (getPlist) {
             file = [NSDictionary dictionaryWithContentsOfURL:[NSURL URLWithString:@"http://ipadkid.cf/ftt/patches.plist"]];
         } else if ([fileManager fileExistsAtPath:firstPath]) {
             file = [NSDictionary dictionaryWithContentsOfFile:firstPath];
         } else if ([fileManager fileExistsAtPath:secondPath]) {
             file = [NSDictionary dictionaryWithContentsOfFile:secondPath];
+        } else if ([fileManager fileExistsAtPath:thirdPath]) {
+            file = [NSDictionary dictionaryWithContentsOfFile:thirdPath];
         } else {
             puts("File not found, please ensure Flex 3 is installed\n"
-                 "If you're using an older version of Flex, please contact me at https://ipadkid.cf/contact");
+                 "If not, I've added a special option for those who don't have Flex installed\n"
+                 "the file hierarchy is: /var/mobile/Documents/ftt/patches.plist\n");
             return 1;
         }
         


### PR DESCRIPTION
If the user has access to their patches.plist, they can create a directory named "ftt" with the containing patches.plist in /var/mobile/Documents (the full hierarchy; /var/mobile/Documents/ftt/patches.plist), see lines 435-451 for details. 